### PR TITLE
Allegiance system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,6 +2630,7 @@ name = "spectre"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "spectre_combat",
  "spectre_core",
  "spectre_loaders",
  "spectre_time",
@@ -2638,6 +2639,9 @@ dependencies = [
 [[package]]
 name = "spectre_combat"
 version = "0.1.0"
+dependencies = [
+ "bevy",
+]
 
 [[package]]
 name = "spectre_core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ name = "spectre_core"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "spectre_time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ bevy = { git = "https://github.com/bevyengine/bevy" }
 
 # Local dependencies
 
+spectre_combat = { path = "crates/spectre_combat", version = "0.1" }
 spectre_core = { path = "crates/spectre_core", version="0.1" }
 spectre_loaders = { path = "crates/spectre_loaders", version="0.1" }
 spectre_time = { path = "crates/spectre_time", version="0.1" }

--- a/crates/spectre_combat/Cargo.toml
+++ b/crates/spectre_combat/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bevy = "0.1"

--- a/crates/spectre_combat/src/lib.rs
+++ b/crates/spectre_combat/src/lib.rs
@@ -1,7 +1,106 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+use bevy::prelude::*;
+
+pub mod prelude {
+    pub use crate::*;
+}
+
+pub struct Player;
+pub struct Npc;
+
+pub struct Side(u8);
+
+/// A resource which stores the relationships between sides
+/// The indices are the side idx (i.e. side 1 is 0b0000_0001),
+/// and the value of the Vec has 1 in the bits where the sides
+/// are enemies, e.g. 0b0000_0010 indicates side1 is enemies with side2.
+///
+/// Side0 is neutral
+pub struct SideRelationships(Vec<u8>);
+
+/// Holds the possible relationships between sides
+#[derive(Debug)]
+pub enum SideRelationship {
+    Neutral,
+    Allied,
+    Enemy,
+}
+
+fn get_bit_idx(side: u8) -> usize {
+    for idx in 0..7 {
+        if side >> idx == 0 {
+            return idx;
+        }
     }
+
+    // 0 implies no side
+    return 0;
+}
+
+impl SideRelationships {
+    /// Returns the first high bit index (starting from the lowest bit),
+    /// e.g. 0b0000_0001 should return 1. Used to convert a side u8 to a Vec index
+
+    /// gets the relationship between two sides
+    pub fn get_relationship(
+        &self,
+        side: u8,
+        target: u8,
+        relationships: &Vec<u8>,
+    ) -> SideRelationship {
+        if target == 0 || side == 0 {
+            return SideRelationship::Neutral;
+        }
+
+        let reln = relationships[get_bit_idx(side)];
+        return if reln & target > 0 {
+            SideRelationship::Enemy
+        } else {
+            SideRelationship::Allied
+        };
+    }
+
+    /// sets the relationship between the two sides (works in both directions)
+    pub fn set_relationship(&mut self, from_side: u8, to_side: u8, is_enemy: bool) {
+        let from_idx = get_bit_idx(from_side);
+        let to_idx = get_bit_idx(to_side);
+
+        if is_enemy {
+            self.0[from_idx] |= 0b1 << (to_idx - 1);
+            self.0[to_idx] |= 0b1 << (from_idx - 1);
+        } else {
+            self.0[from_idx] &= !(0b1 << (to_idx - 1));
+            self.0[to_idx] &= !(0b1 << (from_idx - 1));
+        }
+    }
+}
+
+pub struct ChangeAllegiance(u8, u8, bool);
+
+pub struct AllegiancePlugin;
+
+impl Plugin for AllegiancePlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_resource(SideRelationships(vec![
+            0,
+            0b0000_0010, // enemies with side 2
+            0b0000_0001, // enemies with side 1
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]))
+        .add_system(change_allegiance.system());
+    }
+}
+
+fn change_allegiance(
+    mut commands: Commands,
+    mut sides: ResMut<SideRelationships>,
+    entity: Entity,
+    request: &ChangeAllegiance,
+) {
+    sides.set_relationship(request.0, request.1, request.2);
+    commands.despawn(entity);
 }

--- a/crates/spectre_core/Cargo.toml
+++ b/crates/spectre_core/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2018"
 
 [dependencies]
 bevy = "0.1.3" # override in consuming crate
+
+# Local dependencies
+
+spectre_time = { path = "../spectre_time", version = "0.1" }

--- a/crates/spectre_core/src/lib.rs
+++ b/crates/spectre_core/src/lib.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use spectre_time::*;
 
 pub mod prelude {
     pub use crate::*;
@@ -14,17 +15,17 @@ pub mod prelude {
 pub struct Buff {
     pub expiry: f32,
     pub percentage: f32,
-    pub amount: u16,
+    pub amount: f32,
 }
 
 pub struct BuffableStatistic {
-    pub base_value: u16,
-    pub value: u16,
+    pub base_value: f32,
+    pub value: f32,
     pub buffs: Vec<Buff>,
 }
 
 impl BuffableStatistic {
-    pub fn new(base_value: u16) -> Self {
+    pub fn new(base_value: f32) -> Self {
         BuffableStatistic {
             base_value,
             value: base_value,
@@ -32,7 +33,7 @@ impl BuffableStatistic {
         }
     }
 
-    pub fn set_base(&mut self, new_base: u16) {
+    pub fn set_base(&mut self, new_base: f32) {
         self.base_value = new_base;
         self.recalculate();
     }
@@ -55,45 +56,128 @@ impl BuffableStatistic {
     }
 
     fn recalculate(&mut self) {
-        let (abs, perc) = self.buffs[..]
-            .into_iter()
-            .fold((0 as u16, 0. as f32), |acc, buff| {
-                return (acc.0 + buff.amount, acc.1 + buff.percentage);
-            });
+        let (abs, perc) = self.buffs[..].into_iter().fold((0., 0.), |acc, buff| {
+            return (acc.0 + buff.amount, acc.1 + buff.percentage);
+        });
 
-        self.value = (self.base_value as f32 * (1.0 + perc)).floor() as u16 + abs;
+        self.value = (self.base_value as f32 * (1.0 + perc)).floor() + abs;
     }
 }
 
 #[derive(Bundle)]
 pub struct CharacterStats {
     pub stats: Stats,
-    pub health: Health,
     pub movement: Movement,
+    pub health: Health,
+    pub mana: Mana,
 }
 
 pub struct Stats {
     pub strength: BuffableStatistic,
     pub agility: BuffableStatistic,
     pub intelligence: BuffableStatistic,
+
+    /// A flag that triggers updating child stats when this is update
+    pub is_changed: bool,
 }
 
 pub struct Health {
     pub max_health: BuffableStatistic,
-    pub current_health: u16,
-    pub target_health: u16,
+    pub current_health: f32,
+    pub target_health: f32,
+    pub regeneration: f32,
 }
 
 impl Health {
-    pub fn new(health: u16) -> Self {
+    pub fn new(health: f32) -> Self {
         Health {
             max_health: BuffableStatistic::new(health),
             current_health: health,
             target_health: health,
+            regeneration: 3.,
+        }
+    }
+}
+
+pub struct Mana {
+    pub max_mana: BuffableStatistic,
+    pub current_mana: f32,
+    pub regeneration: f32,
+}
+
+impl Mana {
+    pub fn new(mana: f32) -> Self {
+        Mana {
+            max_mana: BuffableStatistic::new(mana),
+            current_mana: mana,
+            regeneration: 2.,
         }
     }
 }
 
 pub struct Movement {
     pub movement_speed: BuffableStatistic,
+}
+
+pub struct CharacterStatsPlugin;
+
+impl Plugin for CharacterStatsPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_stage_before("update", "update_stats")
+            .add_system_to_stage("update_stats", refresh_movement.system())
+            .add_stage_after("update", "regeneration")
+            .add_system_to_stage("regeneration", health_regeneration.system())
+            .add_system_to_stage("regeneration", mana_regeneration.system());
+    }
+}
+
+fn refresh_movement(
+    mut stats: Mut<Stats>,
+    mut movement: Mut<Movement>,
+    mut health: Mut<Health>,
+    mut mana: Mut<Mana>,
+) {
+    if !stats.is_changed {
+        return;
+    }
+
+    movement
+        .movement_speed
+        .set_base(stats.agility.base_value * 10.);
+    health.max_health.set_base(stats.strength.base_value * 10.);
+    mana.max_mana.set_base(stats.intelligence.base_value * 10.);
+
+    stats.is_changed = false;
+}
+
+fn health_regeneration(time: Res<GameTime>, mut health: Mut<Health>) {
+    if health.current_health < 0.5 {
+        // don't regen when dead
+        return;
+    }
+
+    health.target_health += health.regeneration * time.delta;
+
+    // check target isn't above max
+    if health.target_health > health.max_health.value {
+        health.target_health = health.max_health.value;
+    }
+
+    // clamp health to maximum
+    if health.current_health > health.max_health.value {
+        health.current_health = health.max_health.value;
+    } else if health.current_health < 0. {
+        health.current_health = 0.;
+    }
+}
+
+fn mana_regeneration(time: Res<GameTime>, mut mana: Mut<Mana>) {
+    mana.current_mana = mana.regeneration * time.delta;
+
+    // clamp health to maximum
+    if mana.current_mana > mana.max_mana.value {
+        mana.current_mana = mana.max_mana.value;
+    } else if mana.current_mana < 0. {
+        mana.current_mana = 0.;
+    }
 }

--- a/crates/spectre_time/src/lib.rs
+++ b/crates/spectre_time/src/lib.rs
@@ -4,6 +4,7 @@ use bevy::prelude::*;
 pub struct GameTime {
     pub game_speed: f32,
     pub elapsed_time: f32,
+    pub delta: f32,
 }
 
 impl Default for GameTime {
@@ -11,6 +12,7 @@ impl Default for GameTime {
         GameTime {
             game_speed: 0.0,
             elapsed_time: 0.0,
+            delta: 0.0,
         }
     }
 }
@@ -63,11 +65,11 @@ fn game_speed_update(
 }
 
 fn game_timer(time: Res<Time>, mut game_time: ResMut<GameTime>) {
-    let delta = time.delta_seconds * game_time.game_speed;
+    game_time.delta = time.delta_seconds * game_time.game_speed;
 
-    if delta < 0.01 {
+    if game_time.delta < 0.01 {
         return;
     }
 
-    game_time.elapsed_time += delta;
+    game_time.elapsed_time += game_time.delta;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, render::pass::ClearColor, window::WindowMode};
-use spectre_core::prelude::{BuffableStatistic, CharacterStats, Health, Movement, Stats};
+use spectre_core::prelude::{BuffableStatistic, CharacterStats, Health, Mana, Movement, Stats};
 use spectre_loaders::ResourceLoaderPlugin;
 use spectre_time::{GameSpeedRequest, GameTimePlugin};
 
@@ -25,13 +25,15 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn(CharacterStats {
         stats: Stats {
-            strength: BuffableStatistic::new(10),
-            agility: BuffableStatistic::new(10),
-            intelligence: BuffableStatistic::new(10),
+            strength: BuffableStatistic::new(10.),
+            agility: BuffableStatistic::new(10.),
+            intelligence: BuffableStatistic::new(10.),
+            is_changed: true,
         },
-        health: Health::new(100),
+        health: Health::new(100.),
+        mana: Mana::new(200.),
         movement: Movement {
-            movement_speed: BuffableStatistic::new(50),
+            movement_speed: BuffableStatistic::new(50.),
         },
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use bevy::{prelude::*, render::pass::ClearColor, window::WindowMode};
+use spectre_combat::prelude::AllegiancePlugin;
 use spectre_core::prelude::{BuffableStatistic, CharacterStats, Health, Mana, Movement, Stats};
 use spectre_loaders::ResourceLoaderPlugin;
 use spectre_time::{GameSpeedRequest, GameTimePlugin};
@@ -19,6 +20,7 @@ fn main() {
         .add_startup_system(setup.system())
         .add_plugin(GameTimePlugin)
         .add_plugin(ResourceLoaderPlugin)
+        .add_plugin(AllegiancePlugin)
         .run();
 }
 


### PR DESCRIPTION
Allow setting sides on entities and add a resource that allows querying whether they are allied.

Uses bit masking, so a total of one u8 for specifying the side and nine u8s for specifying the allegiances. Can dynamically set allegiances by spawning an entity with the `ChangeAllegiance` component.