### PR TITLE
Game state management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,6 +2636,7 @@ dependencies = [
  "spectre_combat",
  "spectre_core",
  "spectre_loaders",
+ "spectre_state",
  "spectre_time",
 ]
 
@@ -2667,6 +2668,10 @@ version = "0.1.0"
 dependencies = [
  "bevy",
 ]
+
+[[package]]
+name = "spectre_state"
+version = "0.1.0"
 
 [[package]]
 name = "spectre_time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,6 @@ spectre_animations = { path = "crates/spectre_animations", version = "0.1" }
 spectre_combat = { path = "crates/spectre_combat", version = "0.1" }
 spectre_core = { path = "crates/spectre_core", version="0.1" }
 spectre_loaders = { path = "crates/spectre_loaders", version="0.1" }
+spectre_state = { path = "crates/spectre_state", version="0.1" }
 spectre_time = { path = "crates/spectre_time", version="0.1" }
 

--- a/crates/spectre_state/Cargo.toml
+++ b/crates/spectre_state/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "spectre_state"
+version = "0.1.0"
+authors = ["Will Hart <hart.wl@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/spectre_state/Cargo.toml
+++ b/crates/spectre_state/Cargo.toml
@@ -3,7 +3,3 @@ name = "spectre_state"
 version = "0.1.0"
 authors = ["Will Hart <hart.wl@gmail.com>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/crates/spectre_state/src/lib.rs
+++ b/crates/spectre_state/src/lib.rs
@@ -1,0 +1,79 @@
+#[derive(Debug)]
+pub enum GameStateStatus<T> {
+    Idle,
+    Entered(T),
+    Exiting(T),
+    Running(T),
+}
+
+/// A resource which should be added to the world with a custom scene enum
+#[derive(Debug)]
+pub struct GameState<TScene: Clone + Copy> {
+    pub current: GameStateStatus<TScene>,
+    pub next: Option<TScene>,
+}
+
+impl<TScene: Clone + Copy> GameState<TScene> {
+    /// Set the current transition, to be carried out in the next state update
+    pub fn set_transition(&mut self, next: TScene) {
+        self.next = Some(next);
+    }
+
+    /// Update the state, moving from Idle >> Entering >> Running or
+    /// Running >> Exiting >> Entering >> Running one frame at a time
+    pub fn update(&mut self) {
+        if self.next.is_none() {
+            return;
+        }
+
+        match &self.current {
+            GameStateStatus::Idle => {
+                self.current = GameStateStatus::Entered(self.next.unwrap());
+            }
+            GameStateStatus::Entered(state) => {
+                self.next = None;
+                self.current = GameStateStatus::Running(*state);
+            }
+            GameStateStatus::Exiting(_) => {
+                self.current = GameStateStatus::Entered(self.next.unwrap());
+            }
+            GameStateStatus::Running(state) => {
+                self.current = GameStateStatus::Exiting(*state);
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Copy, Debug)]
+    pub enum TestStates {
+        A,
+        B,
+    }
+
+    #[test]
+    fn transitions_on_update() {
+        let mut gs = GameState::<TestStates> {
+            current: GameStateStatus::Idle,
+            next: Some(TestStates::A),
+        };
+
+        match gs.current {
+            GameStateStatus::Idle => assert!(true),
+            _ => assert!(false),
+        };
+
+        gs.update();
+
+        match gs.current {
+            GameStateStatus::Entered(entered_state) => match entered_state {
+                TestStates::A => assert!(true),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        };
+    }
+}


### PR DESCRIPTION
Adds a simple crate for managing game state. The user needs to provide an enum describing the different possible game states, add a struct as a resource and call `update` on the resource somewhere.  See `main.rs` for an implementation example.