### PR TITLE
File data loaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,11 +136,11 @@ checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
 
 [[package]]
 name = "async-trait"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
@@ -172,13 +172,14 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 [[package]]
 name = "bevy"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_audio",
  "bevy_core",
  "bevy_diagnostic",
+ "bevy_dynamic_plugin",
  "bevy_ecs",
  "bevy_gilrs",
  "bevy_gltf",
@@ -213,13 +214,12 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_math",
  "instant",
- "libloading 0.6.3",
  "log",
  "serde",
  "wasm-bindgen",
@@ -229,7 +229,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "bevy_audio"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -268,7 +268,7 @@ dependencies = [
 [[package]]
 name = "bevy_core"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_derive",
@@ -285,11 +285,11 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -309,9 +309,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_dynamic_plugin"
+version = "0.2.1"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
+dependencies = [
+ "bevy_app",
+ "libloading 0.6.3",
+ "log",
+]
+
+[[package]]
 name = "bevy_ecs"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_hecs",
  "bevy_tasks",
@@ -326,7 +336,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -338,7 +348,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "anyhow",
  "base64",
@@ -352,7 +362,7 @@ dependencies = [
 [[package]]
 name = "bevy_hecs"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_hecs_macros",
  "bevy_utils",
@@ -364,10 +374,10 @@ dependencies = [
 [[package]]
 name = "bevy_hecs_macros"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
@@ -375,7 +385,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -386,7 +396,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "glam",
 ]
@@ -394,7 +404,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -412,7 +422,7 @@ dependencies = [
 [[package]]
 name = "bevy_property"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_ecs",
  "bevy_math",
@@ -427,10 +437,10 @@ dependencies = [
 [[package]]
 name = "bevy_property_derive"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
@@ -438,7 +448,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "anyhow",
  "bevy-glsl-to-spirv",
@@ -472,7 +482,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -491,7 +501,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -510,7 +520,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -523,7 +533,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -539,7 +549,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -554,7 +564,7 @@ dependencies = [
 [[package]]
 name = "bevy_type_registry"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -567,7 +577,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -589,7 +599,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "ahash",
 ]
@@ -597,7 +607,7 @@ dependencies = [
 [[package]]
 name = "bevy_wgpu"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -619,7 +629,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -632,7 +642,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.2.1"
-source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
+source = "git+https://github.com/bevyengine/bevy#4c753e258806999a69c680421ba3804148b4b33c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -659,7 +669,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "regex",
  "rustc-hash",
@@ -1051,7 +1061,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
@@ -1257,7 +1267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
@@ -1406,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-vulkan"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d79e22b4dd093774a1ef771e18ae59aec558a21f48ae494677f5f8ebc067f6"
+checksum = "70aad11a5760d216e3899beac0356560765402f30d2c1eaa79687276c8e006f7"
 dependencies = [
  "arrayvec",
  "ash",
@@ -1526,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6636de7bf52227363554f1ca2d9cd180fc666129ddd0933097e1f227dfa7293"
 dependencies = [
  "inflections",
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
@@ -1589,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.9"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974e194911d1f7efe3cd8a8f9db3b767e43536327e899e8bc9a12ef5711b74d2"
+checksum = "985fc06b1304d19c28d5c562ed78ef5316183f2b0053b46763a0b94862373c34"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1722,9 +1732,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
 
 [[package]]
 name = "libloading"
@@ -2112,7 +2122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
@@ -2230,29 +2240,29 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.23"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
+checksum = "2b9e280448854bd91559252582173b3bd1f8e094a0e644791c0628ca9b1f144f"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.23"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+checksum = "c8c8b352676bc6a4c3d71970560b913cea444a7a921cc2e2d920225e4b91edaa"
 dependencies = [
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
+checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-utils"
@@ -2316,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b93dba1818d32e781f9d008edd577bab215e83ef50e8a1ddf1ad301b19a09f"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2338,7 +2348,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
 ]
 
 [[package]]
@@ -2558,16 +2568,16 @@ version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
@@ -2790,7 +2800,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "serde",
  "serde_derive",
@@ -2804,7 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "serde",
  "serde_derive",
@@ -2846,11 +2856,11 @@ checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -2884,7 +2894,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
 ]
@@ -2900,19 +2910,20 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if",
+ "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
 ]
@@ -3017,7 +3028,7 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
  "wasm-bindgen-shared",
@@ -3051,7 +3062,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
- "proc-macro2 1.0.22",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn",
  "wasm-bindgen-backend",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
 
 [[package]]
+name = "async-trait"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+dependencies = [
+ "proc-macro2 1.0.22",
+ "quote 1.0.7",
+ "syn",
+]
+
+[[package]]
 name = "atom"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,7 +172,7 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 [[package]]
 name = "bevy"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -202,7 +213,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -218,9 +229,10 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bevy_app",
  "bevy_ecs",
  "bevy_property",
@@ -228,18 +240,22 @@ dependencies = [
  "bevy_type_registry",
  "bevy_utils",
  "crossbeam-channel",
+ "js-sys",
  "log",
  "notify",
  "parking_lot 0.11.0",
  "serde",
  "thiserror",
  "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
 name = "bevy_audio"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -252,7 +268,7 @@ dependencies = [
 [[package]]
 name = "bevy_core"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_derive",
@@ -269,11 +285,11 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -281,7 +297,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -295,7 +311,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_hecs",
  "bevy_tasks",
@@ -310,7 +326,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -322,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "anyhow",
  "base64",
@@ -336,7 +352,7 @@ dependencies = [
 [[package]]
 name = "bevy_hecs"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_hecs_macros",
  "bevy_utils",
@@ -348,10 +364,10 @@ dependencies = [
 [[package]]
 name = "bevy_hecs_macros"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -359,7 +375,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -370,7 +386,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "glam",
 ]
@@ -378,7 +394,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -396,7 +412,7 @@ dependencies = [
 [[package]]
 name = "bevy_property"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_ecs",
  "bevy_math",
@@ -411,10 +427,10 @@ dependencies = [
 [[package]]
 name = "bevy_property_derive"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -422,7 +438,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "anyhow",
  "bevy-glsl-to-spirv",
@@ -456,7 +472,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -475,7 +491,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -494,19 +510,20 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "async-channel",
  "async-executor",
  "event-listener",
  "futures-lite",
  "num_cpus",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_text"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -522,7 +539,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -537,7 +554,7 @@ dependencies = [
 [[package]]
 name = "bevy_type_registry"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -550,7 +567,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -572,7 +589,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "ahash",
 ]
@@ -580,7 +597,7 @@ dependencies = [
 [[package]]
 name = "bevy_wgpu"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -602,7 +619,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -615,7 +632,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.2.1"
-source = "git+https://github.com/bevyengine/bevy#3ca0a2b0ac36ddfb7ed36a66806c0e5686d58548"
+source = "git+https://github.com/will-hart/bevy?branch=asset-loader-from-instance#2372b7ad1bcb8bd5ee7f2090e222f4d807c4b1a2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -642,7 +659,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "regex",
  "rustc-hash",
@@ -1034,7 +1051,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -1240,7 +1257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -1509,7 +1526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6636de7bf52227363554f1ca2d9cd180fc666129ddd0933097e1f227dfa7293"
 dependencies = [
  "inflections",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -2095,7 +2112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -2226,7 +2243,7 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -2299,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "e4b93dba1818d32e781f9d008edd577bab215e83ef50e8a1ddf1ad301b19a09f"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2321,7 +2338,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
 ]
 
 [[package]]
@@ -2541,7 +2558,7 @@ version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -2636,6 +2653,7 @@ name = "spectre"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "serde",
  "spectre_animations",
  "spectre_combat",
  "spectre_core",
@@ -2670,7 +2688,10 @@ dependencies = [
 name = "spectre_loaders"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bevy",
+ "ron",
+ "serde",
 ]
 
 [[package]]
@@ -2769,7 +2790,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "serde",
  "serde_derive",
@@ -2783,7 +2804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "serde",
  "serde_derive",
@@ -2829,7 +2850,7 @@ version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -2863,7 +2884,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
 ]
@@ -2996,7 +3017,7 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
  "wasm-bindgen-shared",
@@ -3030,7 +3051,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.22",
  "quote 1.0.7",
  "syn",
  "wasm-bindgen-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,10 @@ codegen-units = 1
 
 [patch.crates-io]
 # Can revert to default branch when PR 580 is merged
-bevy = { git = "https://github.com/will-hart/bevy", branch="asset-loader-from-instance" }
+bevy = { git = "https://github.com/bevyengine/bevy"  }
 
 [dependencies]
-# Can revert to default branch when PR 580 is merged
-bevy = { git = "https://github.com/will-hart/bevy", branch="asset-loader-from-instance" }
+bevy = { git = "https://github.com/bevyengine/bevy" }
 serde = { version = "1", features = ["derive"]}
 
 # Local dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,13 @@ incremental = false
 codegen-units = 1
 
 [patch.crates-io]
-bevy = { git = "https://github.com/bevyengine/bevy" }
+# Can revert to default branch when PR 580 is merged
+bevy = { git = "https://github.com/will-hart/bevy", branch="asset-loader-from-instance" }
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy" }
+# Can revert to default branch when PR 580 is merged
+bevy = { git = "https://github.com/will-hart/bevy", branch="asset-loader-from-instance" }
+serde = { version = "1", features = ["derive"]}
 
 # Local dependencies
 spectre_animations = { path = "crates/spectre_animations", version = "0.1" }

--- a/assets/data/character.chd
+++ b/assets/data/character.chd
@@ -1,0 +1,3 @@
+Character (
+  test: 1
+)

--- a/crates/spectre_loaders/Cargo.toml
+++ b/crates/spectre_loaders/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 bevy = "0.2"
+ron = "0.6"
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/spectre_loaders/src/data_loaders.rs
+++ b/crates/spectre_loaders/src/data_loaders.rs
@@ -1,0 +1,33 @@
+use bevy::asset::AssetLoader;
+use ron::de::from_bytes;
+use serde::de::Deserialize;
+use std::path::Path;
+
+/// A generic data file loader which loads RON files from the assets folder
+/// and deserializes them into the provided type. There should be a 1:1 mapping
+/// between the file extension set and the type of asset loaded
+#[derive(Default)]
+pub struct DataFileLoader {
+    matching_extensions: Vec<&'static str>,
+}
+
+impl DataFileLoader {
+    pub fn from_extensions(matching_extensions: Vec<&'static str>) -> Self {
+        DataFileLoader {
+            matching_extensions,
+        }
+    }
+}
+
+impl<TAsset> AssetLoader<TAsset> for DataFileLoader
+where
+    for<'de> TAsset: Deserialize<'de>,
+{
+    fn from_bytes(&self, _asset_path: &Path, bytes: Vec<u8>) -> Result<TAsset, anyhow::Error> {
+        Ok(from_bytes::<TAsset>(bytes.as_slice())?)
+    }
+
+    fn extensions(&self) -> &[&str] {
+        self.matching_extensions.as_slice()
+    }
+}

--- a/crates/spectre_loaders/src/lib.rs
+++ b/crates/spectre_loaders/src/lib.rs
@@ -21,6 +21,7 @@ pub struct LoadingStatus {
 pub enum LoaderAssetType {
     Untyped,
     // TODO: UntypedDirectory,
+    // TODO: AudioWithId(u128),
     TextureWithId(u128),
 }
 

--- a/crates/spectre_loaders/src/lib.rs
+++ b/crates/spectre_loaders/src/lib.rs
@@ -1,5 +1,7 @@
 use bevy::{asset::Handle, asset::LoadState, prelude::*};
 
+pub mod data_loaders;
+
 pub struct ResourceLoaderPlugin;
 
 impl Plugin for ResourceLoaderPlugin {
@@ -126,7 +128,7 @@ fn texture_loading_system(
     }
 
     println!(
-        "Loaded {} of {} textures",
+        "Loaded {} of {} items",
         loading_status.items_loaded, loading_status.items_to_load
     );
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,19 @@
+use bevy::prelude::*;
+use serde::Deserialize;
+use spectre_loaders::data_loaders::DataFileLoader;
+
+#[derive(Deserialize)]
+pub struct Character {
+    pub test: i32,
+}
+
+pub struct DataFileLoaderPlugin;
+
+impl Plugin for DataFileLoaderPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_asset::<Character>()
+            .add_asset_loader_from_instance::<Character, DataFileLoader>(
+                DataFileLoader::from_extensions(vec!["chd"]),
+            );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use bevy::{prelude::*, render::pass::ClearColor, window::WindowMode};
 use spectre_animations::prelude::AnimationPlugin;
 use spectre_combat::prelude::AllegiancePlugin;
 use spectre_core::prelude::{BuffableStatistic, CharacterStats, Health, Mana, Movement, Stats};
-use spectre_loaders::{ResourceLoaderPlugin, TexturesToLoad};
+use spectre_loaders::{LoadAssets, ResourceLoaderPlugin};
 use spectre_time::{GameSpeedRequest, GameTimePlugin};
 
 mod constants;
@@ -29,7 +29,7 @@ fn main() {
         .add_startup_system(setup.system())
         .add_plugin(GameTimePlugin)
         .add_plugin(ResourceLoaderPlugin)
-        // .add_plugin(DataFileLoaderPlugin)
+        .add_plugin(DataFileLoaderPlugin)
         .add_plugin(AllegiancePlugin)
         .add_plugin(AnimationPlugin)
         .add_plugin(GameStatePlugin)
@@ -57,8 +57,11 @@ fn setup(mut commands: Commands) {
         })
         // this loaders approach requires at least one tick of the game loop before
         // assets handles are available, therefore can't directly spawn player sprite here
-        .spawn((TexturesToLoad {
-            textures: vec![("assets/walk_sprite_sheet.png", ANIMATED_SPRITESHEED_ID).into()],
+        .spawn((LoadAssets {
+            assets: vec![("assets/walk_sprite_sheet.png", ANIMATED_SPRITESHEED_ID)]
+                .into_iter()
+                .map(|a| a.into())
+                .collect(),
         },))
         // start the game clock running
         .spawn((GameSpeedRequest::new(1.0),));

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,11 @@ use spectre_loaders::{ResourceLoaderPlugin, TexturesToLoad};
 use spectre_time::{GameSpeedRequest, GameTimePlugin};
 
 mod constants;
+mod data;
 mod game_scenes;
 
 use constants::ANIMATED_SPRITESHEED_ID;
+use data::DataFileLoaderPlugin;
 use game_scenes::*;
 
 fn main() {
@@ -27,6 +29,7 @@ fn main() {
         .add_startup_system(setup.system())
         .add_plugin(GameTimePlugin)
         .add_plugin(ResourceLoaderPlugin)
+        // .add_plugin(DataFileLoaderPlugin)
         .add_plugin(AllegiancePlugin)
         .add_plugin(AnimationPlugin)
         .add_plugin(GameStatePlugin)


### PR DESCRIPTION
NOTE: Requires bevy PR 580 to be merged before merging this

Adds support for generic RON data files to be loaded as strongly typed assets.

- [x] Generic data loader
- [x] Support in bevy for generic data loader (PR 580)
- [x] Implement `TexturesToLoad` equivalent for data files